### PR TITLE
Fixed rep and selectedProfile not being defined for offline or demo accounts

### DIFF
--- a/spock/plugins/core/auth.py
+++ b/spock/plugins/core/auth.py
@@ -28,6 +28,7 @@ class AuthCore:
 		self.ygg = yggdrasil.YggAuth()
 
 	def start_session(self, username, password = ''):
+		rep = {}
 		if self.authenticated:
 			print(
 				"Attempting login with username:", username,
@@ -40,8 +41,11 @@ class AuthCore:
 				print('Login Unsuccessful, Response:', rep)
 				self.event.emit('AUTH_ERR')
 				return rep
-			self.selected_profile = rep['selectedProfile']
-			self.username = rep['selectedProfile']['name']
+			if 'selectedProfile' in rep:
+				self.selected_profile = rep['selectedProfile']
+				self.username = rep['selectedProfile']['name']
+			else:
+				self.username = username
 		else:
 			self.username = username
 		return rep


### PR DESCRIPTION
For demo accounts the authentication returns a valid response except for selectedProfiles is empty.
For non authenticated accounts rep was not defined so it would crash out.