### PR TITLE
Fixed off by one error in packet size, and datatype of keep_alive

### DIFF
--- a/spock/mcp/mcdata.py
+++ b/spock/mcp/mcdata.py
@@ -344,7 +344,7 @@ packet_structs = {
 		SERVER_TO_CLIENT: {
 			#Keep Alive
 			0x00: (
-				(MC_INT, 'keep_alive'),
+				(MC_VARINT, 'keep_alive'),
 			),
 			#Join Game
 			0x01: (

--- a/spock/mcp/mcpacket.py
+++ b/spock/mcp/mcpacket.py
@@ -68,7 +68,7 @@ class Packet(object):
 			o += hashed_extensions[self.__hashed_ident].encode_extra(self)
 
 		if proto_comp_state == mcdata.PROTO_COMP_ON:
-			uncompressed_len = len(o)
+			uncompressed_len = len(o) + 1
 			if uncompressed_len < proto_comp_threshold:
 				header = datautils.pack(MC_VARINT, uncompressed_len)
 				header += datautils.pack(MC_VARINT, 0)


### PR DESCRIPTION
Keep Alive packed send from the server
`b'\x06\x00\x00\xc5\xf6\xf3\t'`
Keep Alive packet sent back to server
`b'\x05\x00\x00\xc5\xf6\xf3\t'`

This would cause the minecraft server to drop the client because it failed to decode the packet